### PR TITLE
add note that only emoncms.org only supports numerical node ID's

### DIFF
--- a/data/home.html
+++ b/data/home.html
@@ -94,7 +94,7 @@
 				<span>e.g 'data.openevse.com', 'emoncms.org','192.168.1.4/emoncms'</span><br>
 				<p><b>Node:</b><br>
 				<input id="emoncms_node" type="text" value="0">
-				</p><span>Note: EmonCMS only supports numberical nodeID's 1-32</span><br><br>
+				</p><span>Note: Emoncms.org only supports numberical nodeID's 1-32</span><br><br>
 				<p><b>Write apikey*:</b><br>
 				<input id="emoncms_apikey" type="text"><br>
 				<p><b>SSL SSH-1 Fingerprint:</b><br>


### PR DESCRIPTION
Emoncms from current master branch as running emonPi / pre built emonSD supports alphanumeric node naming as well as numerical node ID's.